### PR TITLE
Translation of Isaacs tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,16 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-surefire-plugin</artifactId>
+		        <version>2.12.4</version>
+		        <configuration>
+		          <includes>
+		            <include>AllMinimatchTest.java</include>
+		          </includes>
+		        </configuration>
+		    </plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		        <version>2.12.4</version>
 		        <configuration>
 		          <includes>
-		            <include>AllMinimatchTest.java</include>
+		            <include>**/AllMinimatchTests.java</include>
 		          </includes>
 		        </configuration>
 		    </plugin>

--- a/src/main/java/minimatch/Options.java
+++ b/src/main/java/minimatch/Options.java
@@ -44,64 +44,72 @@ public class Options {
 		return allowWindowsPaths;
 	}
 
-	public void setAllowWindowsPaths(boolean allowWindowsPaths) {
+	public Options setAllowWindowsPaths(boolean allowWindowsPaths) {
 		this.allowWindowsPaths = allowWindowsPaths;
+		return this;
 	}
 
 	public boolean isNocomment() {
 		return nocomment;
 	}
 
-	public void setNocomment(boolean nocomment) {
+	public Options setNocomment(boolean nocomment) {
 		this.nocomment = nocomment;
+		return this;
 	}
 
 	public boolean isNonegate() {
 		return nonegate;
 	}
 
-	public void setNonegate(boolean nonegate) {
+	public Options setNonegate(boolean nonegate) {
 		this.nonegate = nonegate;
+		return this;
 	}
 
 	public boolean isNobrace() {
 		return nobrace;
 	}
 
-	public void setNobrace(boolean nobrace) {
+	public Options setNobrace(boolean nobrace) {
 		this.nobrace = nobrace;
+		return this;
 	}
 
 	public boolean isNoglobstar() {
 		return noglobstar;
 	}
 
-	public void setNoglobstar(boolean noglobstar) {
+	public Options setNoglobstar(boolean noglobstar) {
 		this.noglobstar = noglobstar;
+		return this;
 	}
 
 	public boolean isNocase() {
 		return nocase;
 	}
 
-	public void setNocase(boolean nocase) {
+	public Options setNocase(boolean nocase) {
 		this.nocase = nocase;
+		return this;
 	}
 
 	public boolean isDot() {
 		return dot;
 	}
 
-	public void setDot(boolean dot) {
+	public Options setDot(boolean dot) {
 		this.dot = dot;
+		return this;
 	}
 
 	public boolean isNoext() {
 		return noext;
 	}
 
-	public void setNoext(boolean noext) {
+	public Options setNoext(boolean noext) {
 		this.noext = noext;
+		return this;
 	}
 
 	public boolean isDebug() {
@@ -112,24 +120,58 @@ public class Options {
 		return matchBase;
 	}
 
-	public void setMatchBase(boolean matchBase) {
+	public Options setMatchBase(boolean matchBase) {
 		this.matchBase = matchBase;
+		return this;
 	}
 
 	public boolean isFlipNegate() {
 		return flipNegate;
 	}
 
-	public void setFlipNegate(boolean flipNegate) {
+	public Options setFlipNegate(boolean flipNegate) {
 		this.flipNegate = flipNegate;
+		return this;
 	}
 
 	public Debugger getDebugger() {
 		return debugger;
 	}
 
-	public void setDebugger(Debugger debugger) {
+	public Options setDebugger(Debugger debugger) {
 		this.debugger = debugger;
+		return this;
+	}
+	
+	@Override
+	@SuppressWarnings("nls")
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		appendIfTrue(sb, "allowWindowsPaths", allowWindowsPaths);
+		appendIfTrue(sb, "nocomment", nocomment);
+		appendIfTrue(sb, "nonegate", nonegate);
+		appendIfTrue(sb, "nobrace", nobrace);
+		appendIfTrue(sb, "noglobstar", noglobstar);
+		appendIfTrue(sb, "nocase", nocase);
+		appendIfTrue(sb, "dot", dot);
+		appendIfTrue(sb, "noext", noext);
+		appendIfTrue(sb, "matchBase", matchBase);
+		appendIfTrue(sb, "flipNegate", flipNegate);
+		if (sb.length() > 0) {
+			sb.insert(0, "[");
+			sb.setLength(sb.length() - 2);
+			sb.append("]");
+			return sb.toString();
+		} else {
+			return "[]";
+		}
+	}
+	
+	private void appendIfTrue(StringBuilder str, String name, boolean value) {
+		if (value) {
+			str.append(name);
+			str.append("=true, "); //$NON-NLS-1$
+		}
 	}
 
 }

--- a/src/test/java/minimatch/AbstractMinimatchTest.java
+++ b/src/test/java/minimatch/AbstractMinimatchTest.java
@@ -1,0 +1,74 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Genuitec LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package minimatch;
+
+import org.junit.Test;
+
+/**
+ * Base class for minimatch pattern tests.
+ * 
+ * @author Piotr Tomiak <piotr@genuitec.com>
+ */
+public class AbstractMinimatchTest {
+	
+	private final ITestCase testCase;
+	
+	public AbstractMinimatchTest(ITestCase testCase) {
+		this.testCase = testCase;
+	}
+	
+	@Test
+	public void runTestCase() {
+		testCase.run();
+	}
+	
+	public interface ITestCase {
+		
+		void run();
+		
+	}
+	
+	public abstract static class AbstractTestCase implements ITestCase {
+		
+		protected TestCase testCase;
+		
+		@Override
+		public void run() {
+			try {
+				internalRun();
+			} catch (Error err) {
+				testCase.setAsCauseOf(err);
+				throw err;
+			} catch (RuntimeException ex) {
+				testCase.setAsCauseOf(ex);
+				throw ex;
+			}
+		}
+		
+		protected abstract void internalRun();
+		
+	}
+	
+	
+}

--- a/src/test/java/minimatch/AllMinimatchTests.java
+++ b/src/test/java/minimatch/AllMinimatchTests.java
@@ -1,0 +1,47 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Genuitec LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package minimatch;
+
+import minimatch.isaacs.ExtglobEndingWithStateChar;
+import minimatch.isaacs.Patterns;
+import minimatch.isaacs.TrickyNegations;
+import minimatch.java.FootTest;
+import minimatch.java.PatternWichStartsWithExcludeTest;
+import minimatch.java.PatternWichStartsWithSlashTest;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	Patterns.class,
+	TrickyNegations.class,
+	FootTest.class,
+	ExtglobEndingWithStateChar.class,
+	PatternWichStartsWithExcludeTest.class,
+	PatternWichStartsWithSlashTest.class
+})
+
+public class AllMinimatchTests {
+}

--- a/src/test/java/minimatch/AllMinimatchTests.java
+++ b/src/test/java/minimatch/AllMinimatchTests.java
@@ -24,8 +24,6 @@
 package minimatch;
 
 import minimatch.isaacs.ExtglobEndingWithStateChar;
-import minimatch.isaacs.Patterns;
-import minimatch.isaacs.TrickyNegations;
 import minimatch.java.FootTest;
 import minimatch.java.PatternWichStartsWithExcludeTest;
 import minimatch.java.PatternWichStartsWithSlashTest;
@@ -35,8 +33,8 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	Patterns.class,
-	TrickyNegations.class,
+//	Patterns.class,
+//	TrickyNegations.class,
 	FootTest.class,
 	ExtglobEndingWithStateChar.class,
 	PatternWichStartsWithExcludeTest.class,

--- a/src/test/java/minimatch/TestCase.java
+++ b/src/test/java/minimatch/TestCase.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Genuitec LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package minimatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to ease with locating tested pattern in the source code. It should be
+ * instantiated in the test case constructor and set as cause of exception if 
+ * test fails.
+ * 
+ * @author Piotr Tomiak <piotr@genuitec.com>
+ */
+public class TestCase extends Throwable {
+
+	private static final long serialVersionUID = 1L;
+
+	public TestCase(String message) {
+		super(message);
+		List<StackTraceElement> list = new ArrayList<StackTraceElement>();
+		for (StackTraceElement el: getStackTrace()) {
+			if (!el.getMethodName().equals("<init>")) { //$NON-NLS-1$
+				list.add(el);
+			}
+		}
+		setStackTrace(list.toArray(new StackTraceElement[0]));
+	}
+	
+	public void setAsCauseOf(Throwable t) {
+		while (t.getCause() != null) {
+			t = t.getCause();
+		}
+		t.initCause(this);
+	}
+	
+}

--- a/src/test/java/minimatch/isaacs/ExtglobEndingWithStateChar.java
+++ b/src/test/java/minimatch/isaacs/ExtglobEndingWithStateChar.java
@@ -21,7 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package minimatch;
+package minimatch.isaacs;
+
+import minimatch.Minimatch;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/minimatch/isaacs/Patterns.java
+++ b/src/test/java/minimatch/isaacs/Patterns.java
@@ -1,0 +1,363 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Genuitec LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package minimatch.isaacs;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import minimatch.AbstractMinimatchTest;
+import minimatch.Minimatch;
+import minimatch.Options;
+import minimatch.TestCase;
+import minimatch.AbstractMinimatchTest.AbstractTestCase;
+import minimatch.AbstractMinimatchTest.ITestCase;
+
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Translation of https://github.com/isaacs/minimatch/blob/master/test/patterns.js
+ * 
+ * @author Piotr Tomiak <piotr@genuitec.com>
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings("nls")
+public class Patterns extends AbstractMinimatchTest {
+
+	protected static List<String> files = new ArrayList<String>();
+
+	public static List<String> lst(String... items) {
+		return Arrays.asList(items);
+	}
+	
+	/* Tests */
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> patterns() {
+		files.clear();
+		files.addAll(Arrays.asList(new String[] { "a", "b",
+				"c", "d", "abc", "abd", "abe", "bb", "bcd", "ca", "cb", "dd",
+				"de", "bdir/", "bdir/cfile" }));
+		return Arrays.asList(new Object[][] {
+				/* http://www.bashcookbook.com/bashinfo/source/bash-1.14.7/tests/glob-test */
+				//expansion is not yet supported, so some tests are not present
+				{new Test("a*", lst("a", "abc", "abd", "abe"))},
+				
+				//escaped star should not match
+				{new Test("\\*", lst())}, 
+				{new Test("\\**", lst())},
+				{new Test("\\*\\*", lst())},
+				
+				{new Test("b*/", lst("bdir/"))},
+				{new Test("c*",  lst("c", "ca", "cb"))},
+				{new Test("**",  files)},
+				
+				/* legendary larry crashes bashes - doesn't match anything but should not blow up */
+				{new Test("/^root:/{s/^[^:]*:[^:]*:([^:]*).*$/\\1/", lst())},
+				{new Test("/^root:/{s/^[^:]*:[^:]*:([^:]*).*$/\u0001/", lst())},
+				
+				/* Character classes */
+				{new Test("[a-c]b*", 	lst("abc", "abd", "abe", "bb", "cb"))},
+				{new Test("[a-y]*[^c]", lst("abd", "abe", "bb", "bcd", "bdir/", "ca", "cb", "dd", "de"))},
+				{new AddFiles("a-b", "aXb")},
+				{new Test("a[X-]b", 	lst("a-b", "aXb"))},
+				  
+				{new AddFiles(".x", ".y")},
+				{new Test("[^a-c]*", 	lst("d", "dd", "de"))},
+				{new AddFiles("a*b/", "a*b/ooo")},
+				{new Test("a\\*b/*", lst("a*b/ooo"))},
+				{new Test("a\\*?/*", lst("a*b/ooo"))},
+				{new Test("*\\\\!*", lst(), lst("echo !7"))},
+				{new Test("*\\!*", lst("echo !7"), lst("echo !7"))},
+				{new Test("*.\\*", lst("r.*"), lst("r.*"))},
+				{new Test("a[b]c", lst("abc"))},
+				{new Test("a[\\b]c", lst("abc"))},
+				{new Test("a?c", lst("abc"))},
+				{new Test("a\\*c", lst(), lst("abc"))},
+				{new Test("", lst(""), lst(""))},
+				
+				/* http://www.opensource.apple.com/source/bash/bash-23/bash/tests/glob-test */
+				{new AddFiles("man/", "man/man1/", "man/man1/bash.1") },
+				{new Test("*/man*/bash.*", lst("man/man1/bash.1"))},
+				{new Test("man/man1/bash.1", lst("man/man1/bash.1"))},
+				{new Test("a***c", lst("abc"), lst("abc"))},
+				{new Test("a*****?c", lst("abc"), lst("abc"))},
+				{new Test("?*****??", lst("abc"), lst("abc"))},
+				{new Test("*****??", lst("abc"), lst("abc"))},
+				{new Test("?*****?c", lst("abc"), lst("abc"))},
+				{new Test("?***?****c", lst("abc"), lst("abc"))},
+				{new Test("?***?****?", lst("abc"), lst("abc"))},
+				{new Test("?***?****", lst("abc"), lst("abc"))},
+				{new Test("*******c", lst("abc"), lst("abc"))},
+				{new Test("*******?", lst("abc"), lst("abc"))},
+				{new Test("a*cd**?**??k", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("a**?**cd**?**??k", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("a**?**cd**?**??k***", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("a**?**cd**?**??***k", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("a**?**cd**?**??***k**", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("a****c**?**??*****", lst("abcdecdhjk"), lst("abcdecdhjk"))},
+				{new Test("[-abc]", lst("-"), lst("-"))},
+				{new Test("[abc-]", lst("-"), lst("-"))},
+				{new Test("\\", lst("\\"), lst("\\"))},
+				{new Test("[\\\\]", lst("\\"), lst("\\"))},
+				{new Test("[[]", lst("["), lst("["))},
+				{new Test("[", lst("["), lst("["))},
+				{new Test("[*", lst("[abc"), lst("[abc"))},	
+				
+				/* a right bracket shall lose its special meaning and
+				   represent itself in a bracket expression if it occurs
+				   first in the list.  -- POSIX.2 2.8.3.2 */
+				{new Test("[]]", lst("]"), lst("]"))},
+				{new Test("[]-]", lst("]"), lst("]"))},
+				{new Test("[a-z]", lst("p"), lst("p"))},
+				{new Test("??**********?****?", lst(), lst("abc"))},
+				{new Test("??**********?****c", lst(), lst("abc"))},
+				{new Test("?************c****?****", lst(), lst("abc"))},
+				{new Test("*c*?**", lst(), lst("abc"))},
+				{new Test("a*****c*?**", lst(), lst("abc"))},
+				{new Test("a********???*******", lst(), lst("abc"))},
+				{new Test("[]", lst(), lst("a"))},
+				{new Test("[abc", lst(), lst("["))},
+			
+				/* nocase tests */
+				{new Test("XYZ", lst("xYz"), lst("xYz", "ABC", "IjK"), new Options().setNocase(true))},
+				{new Test("ab*", lst("ABC"), lst("xYz", "ABC", "IjK"), new Options().setNocase(true))},
+				{new Test("[ia]?[ck]", lst("ABC", "IjK"), lst("xYz", "ABC", "IjK"), new Options().setNocase(true))},
+
+				// [ pattern, [matches], MM opts, files, TAP opts]
+				/* onestar/twostar */
+				{new Test("{/*,*}", lst(), lst("/asdf/asdf/asdf"))},
+				{new Test("{/?,*}", lst("/a", "bb"), lst("/a", "/b/b", "/a/b/c", "bb"))},
+
+				// dots should not match unless requested",
+				{new Test("**", lst("a/b"), lst("a/b", "a/.d", ".a/.d"))},
+
+				// .. and . can only match patterns starting with .,
+				// even when options.dot is set.
+				{new SetFiles("a/./b", "a/../b", "a/c/b", "a/.d/b")},
+				{new Test("a/*/b", lst("a/c/b", "a/.d/b"), new Options().setDot(true))},
+				{new Test("a/.*/b", lst("a/./b", "a/../b", "a/.d/b"), new Options().setDot(true))},
+				{new Test("a/*/b", lst("a/c/b"), new Options().setDot(false))},
+				{new Test("a/.*/b", lst("a/./b", "a/../b", "a/.d/b"), new Options().setDot(true))},
+
+				// this also tests that changing the options needs
+				// to change the cache key, even if the pattern is
+				// the same!
+				{new Test("**", lst("a/b", "a/.d", ".a/.d"), lst(".a/.d", "a/.d", "a/b"), new Options().setDot(true))},
+
+				/* paren sets cannot contain slashes */
+				{new Test("*(a/b)", lst(), lst("a/b"))},
+
+				// brace sets trump all else.
+				//
+				// invalid glob pattern.  fails on bash4 and bsdglob.
+				// however, in this implementation, it"s easier just
+				// to do the intuitive thing, and let brace-expansion
+				// actually come before parsing any extglob patterns,
+				// like the documentation seems to say.
+				//
+				// XXX: if anyone complains about this, either fix it
+				// or tell them to grow up and stop complaining.
+				//
+				// bash/bsdglob says this:
+				// {new Test("*(a|{b),c)}", lst("*(a|{b),c)}"), lst("a", "ab", "ac", "ad"]]
+				// but we do this instead:
+				{new Test("*(a|{b),c)}", lst("a", "ab", "ac"), lst("a", "ab", "ac", "ad"))},
+
+				// test partial parsing in the presence of comment/negation chars
+				{new Test("[!a*", lst("[!ab"), lst("[!ab", "[ab"))},
+				{new Test("[#a*", lst("[#ab"), lst("[#ab", "[ab"))},
+
+				// like: {a,b|c\\,d\\\|e} except it"s unclosed, so it has to be escaped.
+				{new Test("+(a|*\\|c\\\\|d\\\\\\|e\\\\\\\\|f\\\\\\\\\\|g",
+						lst("+(a|b\\|c\\\\|d\\\\|e\\\\\\\\|f\\\\\\\\|g"),
+						lst("+(a|b\\|c\\\\|d\\\\|e\\\\\\\\|f\\\\\\\\|g", "a", "b\\c"))},
+
+				// crazy nested {,,} and *(||) tests.
+				{new SetFiles(
+						"a", "b", "c", "d", "ab", "ac", "ad", "bc", "cb", "bc,d",
+						"c,db", "c,d", "d)", "(b|c", "*(b|c", "b|c", "b|cc", "cb|c",
+						"x(a|b|c)", "x(a|c)", "(a|b|c)", "(a|c)")},
+				{new Test("*(a|{b,c})", lst("a", "b", "c", "ab", "ac"))},
+				{new Test("{a,*(b|c,d)}", lst("a", "(b|c", "*(b|c", "d)"))},
+				
+				// a
+				// *(b|c)
+				// *(b|d)
+				{new Test("{a,*(b|{c,d})}", lst("a", "b", "bc", "cb", "c", "d"))},
+				{new Test("*(a|{b|c,c})", lst("a", "b", "c", "ab", "ac", "bc", "cb"))},
+
+				// test various flag settings.
+				{new Test("*(a|{b|c,c})", lst("x(a|b|c)", "x(a|c)", "(a|b|c)", "(a|c)"), new Options().setNoext(true))},
+				{new Test("a?b", lst("x/y/acb", "acb/"), lst("x/y/acb", "acb/", "acb/d/e", "x/y/acb/d"), new Options().setMatchBase(true))},
+				{new Test("#*", lst("#a", "#b"), lst("#a", "#b", "c#d"), new Options().setNocomment(true))},
+
+				// begin channelling Boole and deMorgan...
+				// negation tests
+				{new SetFiles("d", "e", "!ab", "!abc", "a!b", "\\!a")},
+
+				// anything that is NOT a* matches.
+				{new Test("!a*", lst("\\!a", "d", "e", "!ab", "!abc"))},
+
+				// anything that IS !a* matches.
+				{new Test("!a*", lst("!ab", "!abc"), new Options().setNonegate(true))},
+
+				// anything that IS a* matches
+				{new Test("!!a*", lst("a!b"))},
+
+				// anything that is NOT !a* matches
+				{new Test("!\\!a*", lst("a!b", "d", "e", "\\!a"))},
+
+				// negation nestled within a pattern
+				{new SetFiles(
+						"foo.js",
+						"foo.bar",
+						"foo.js.js",
+						"blar.js",
+						"foo.",
+						"boo.js.boo"
+					)
+				},
+				// last one is tricky! * matches foo, . matches ., and "js.js" != "js"
+				// copy bash 4.3 behavior on this.
+				{new Test("*.!(js)", lst("foo.bar", "foo.", "boo.js.boo", "foo.js.js"))},
+
+				/* https://github.com/isaacs/minimatch/issues/5 */
+				{new SetFiles(
+						"a/b/.x/c", "a/b/.x/c/d", "a/b/.x/c/d/e", "a/b/.x", "a/b/.x/",
+						"a/.x/b", ".x", ".x/", ".x/a", ".x/a/b", "a/.x/b/.x/c", ".x/.x"
+					)
+				},
+				{new Test("**/.x/**", lst(
+				      ".x/", ".x/a", ".x/a/b", "a/.x/b", "a/b/.x/", "a/b/.x/c",
+				      "a/b/.x/c/d", "a/b/.x/c/d/e"))},
+
+				/* https://github.com/isaacs/minimatch/issues/59 */
+				{new Test("[z-a]", lst())},
+				{new Test("a/[2015-03-10T00:23:08.647Z]/z", lst())},
+				{new Test("[a-0][a-\u0100]", lst())},
+				  
+		});
+	}
+	
+	public Patterns(ITestCase testCase) {
+		super(testCase);
+	}
+	
+	private static class Test extends AbstractTestCase {
+
+		private static int nextId = 1;
+		
+		protected final String pattern;
+		protected final Set<String> expectedOutput;
+		protected final Options options;
+		protected final List<String> files;
+		private final int id;
+
+		public Test(String pattern, List<String> expectedOutput) {
+			this(pattern, expectedOutput, Patterns.files, null);
+		}
+		
+		public Test(String pattern, List<String> expectedOutput, List<String> files) {
+			this(pattern, expectedOutput, files, null);
+		}
+		
+		public Test(String pattern, List<String> expectedOutput, Options options) {
+			this(pattern, expectedOutput, Patterns.files, options);
+		}
+		
+		public Test(String pattern, List<String> expectedOutput, List<String> files, Options options) {
+			this.pattern = pattern;
+			this.expectedOutput = new HashSet<String>(expectedOutput);
+			this.options = options;
+			this.files = files;
+			this.id = nextId++;
+			testCase = new TestCase(toString());
+		}
+		
+		@Override
+		protected void internalRun() {
+			Minimatch mm = new Minimatch(pattern, options);
+			Set<String> matched = new HashSet<String>();
+			for (String file: files) {
+				if (mm.match(file)) {
+					matched.add(file);
+				}
+			}
+			Assert.assertEquals("Pattern matching failed", expectedOutput, matched);
+		}
+		
+		@Override
+		public String toString() {
+			return MessageFormat.format("Pattern {0}{1}: {2}", 
+					id, options != null ? options : "", pattern);
+		}
+		
+	}
+		
+	private static class AddFiles implements ITestCase {
+		
+		private String[] fileNames;
+		
+		public AddFiles(String... fileNames) {
+			this.fileNames = fileNames;
+		}
+		
+		@Override
+		public void run() {
+			files.addAll(Arrays.asList(fileNames));
+		}
+		
+		@Override
+		public String toString() {
+			return "Add files: " + Arrays.toString(fileNames);
+		}
+	}
+	
+	private static class SetFiles implements ITestCase {
+		
+		private String[] fileNames;
+		
+		public SetFiles(String... fileNames) {
+			this.fileNames = fileNames;
+		}
+		
+		@Override
+		public void run() {
+			files.clear();
+			files.addAll(Arrays.asList(fileNames));
+		}
+		
+		@Override
+		public String toString() {
+			return "Set files: " + Arrays.toString(fileNames);
+		}
+	}
+	
+}

--- a/src/test/java/minimatch/isaacs/TrickyNegations.java
+++ b/src/test/java/minimatch/isaacs/TrickyNegations.java
@@ -1,0 +1,208 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Genuitec LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package minimatch.isaacs;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import minimatch.AbstractMinimatchTest;
+import minimatch.Minimatch;
+import minimatch.TestCase;
+import minimatch.AbstractMinimatchTest.AbstractTestCase;
+import minimatch.AbstractMinimatchTest.ITestCase;
+
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Translation of https://github.com/isaacs/minimatch/blob/master/test/tricky-negations.js
+ * 
+ * @author Piotr Tomiak <piotr@genuitec.com>
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings("nls")
+public class TrickyNegations extends AbstractMinimatchTest {
+
+
+	private static final List<Object[]> TESTS = new ArrayList<Object[]>();
+	
+	static {
+		addTests("bar.min.js",
+				new Case("*.!(js|css)", true),
+				new Case("!*.+(js|css)", false),
+				new Case("*.+(js|css)", true)
+		);
+		
+		addTests("a-integration-test.js",
+				new Case("*.!(j)", true),
+				new Case("!(*-integration-test.js)", false),
+				new Case("*-!(integration-)test.js", true),
+				new Case("*-!(integration)-test.js", false),
+				new Case("*!(-integration)-test.js", true),
+				new Case("*!(-integration-)test.js", true),
+				new Case("*!(integration)-test.js", true),
+				new Case("*!(integration-test).js", true),
+				new Case("*-!(integration-test).js", true),
+				new Case("*-!(integration-test.js)", true),
+				new Case("*-!(integra)tion-test.js", false),
+				new Case("*-integr!(ation)-test.js", false),
+				new Case("*-integr!(ation-t)est.js", false),
+				new Case("*-i!(ntegration-)test.js", false),
+				new Case("*i!(ntegration-)test.js", true),
+				new Case("*te!(gration-te)st.js", true),
+				new Case("*-!(integration)?test.js", false),
+				new Case("*?!(integration)?test.js", true)
+		);
+
+		addTests("foo-integration-test.js",
+				new Case("foo-integration-test.js", true),
+				new Case("!(*-integration-test.js)", false)
+		);
+
+		addTests("foo.jszzz.js",
+				new Case("*.!(js).js", true)
+		);
+
+		addTests("asd.jss",
+				new Case("*.!(js)", true)
+		);
+
+		addTests("asd.jss.xyz",
+				new Case("*.!(js).!(xy)", true)
+		);
+
+		addTests("asd.jss.xy",
+				new Case("*.!(js).!(xy)", false)
+		);
+
+		addTests("asd.js.xyz",
+				new Case("*.!(js).!(xy)", false)
+		);
+
+		addTests("asd.js.xy",
+				new Case("*.!(js).!(xy)", false)
+		);
+
+		addTests("asd.sjs.zxy",
+				new Case("*.!(js).!(xy)", true)
+		);
+
+		addTests("asd..xyz",
+				new Case("*.!(js).!(xy)", true)
+		);
+
+		addTests("asd..xy",
+				new Case("*.!(js).!(xy)", false),
+				new Case("*.!(js|x).!(xy)", false)
+		);
+
+		addTests("foo.js.js",
+				new Case("*.!(js)", true)
+		);
+
+		addTests("testjson.json",
+				new Case("*(*.json|!(*.js))", true),
+				new Case("+(*.json|!(*.js))", true),
+				new Case("@(*.json|!(*.js))", true),
+				new Case("?(*.json|!(*.js))", true)
+		);
+
+		addTests("foojs.js",
+				new Case("*(*.json|!(*.js))", false), // XXX bash 4.3 disagrees!
+				new Case("+(*.json|!(*.js))", false), // XXX bash 4.3 disagrees!
+				new Case("@(*.json|!(*.js))", false),
+				new Case("?(*.json|!(*.js))", false)
+		);
+
+		addTests("other.bar",
+				new Case("*(*.json|!(*.js))", true),
+				new Case("+(*.json|!(*.js))", true),
+				new Case("@(*.json|!(*.js))", true),
+				new Case("?(*.json|!(*.js))", true)
+		);
+		
+		
+	}
+
+	
+	private static void addTests(String file, Case... cases) {
+		for (Case c: cases) {
+			TESTS.add(new Object[] {new Test(file, c)});
+		}
+	}
+	
+	/* Tests */
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> tests() {
+		return TESTS;
+	}
+	
+	public TrickyNegations(ITestCase testCase) {
+		super(testCase);
+	}
+
+	private static class Test extends AbstractTestCase {
+
+		private static int nextId = 1;
+		
+		private String file;
+		private Case c;
+		private int id;
+		
+		public Test(String file, Case c) {
+			this.c = c;
+			this.file = file;
+			this.id = nextId++;
+			this.testCase = c.testCase;
+		}
+		
+		@Override
+		public void internalRun() {
+			Assert.assertEquals("Pattern matching failed", c.shouldPass, 
+					new Minimatch(c.pattern).match(file));
+		}
+		
+		@Override
+		public String toString() {
+			return MessageFormat.format("{0}. File: {1}, pattern: {2}", id, file, c.pattern);
+		}
+		
+	}
+	
+	private static class Case {
+		public final String pattern;
+		public final boolean shouldPass;
+		public final TestCase testCase;
+		
+		public Case(String pattern, boolean shouldPass) {
+			this.pattern = pattern;
+			this.shouldPass = shouldPass;
+			this.testCase = new TestCase("Pattern: " +pattern);
+		}
+	}
+	
+}

--- a/src/test/java/minimatch/java/FootTest.java
+++ b/src/test/java/minimatch/java/FootTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package minimatch;
+package minimatch.java;
 
 import minimatch.Minimatch;
 import minimatch.Options;

--- a/src/test/java/minimatch/java/PatternWichStartsWithExcludeTest.java
+++ b/src/test/java/minimatch/java/PatternWichStartsWithExcludeTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package minimatch;
+package minimatch.java;
 
 import minimatch.Minimatch;
 import minimatch.Options;

--- a/src/test/java/minimatch/java/PatternWichStartsWithSlashTest.java
+++ b/src/test/java/minimatch/java/PatternWichStartsWithSlashTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package minimatch;
+package minimatch.java;
 
 import minimatch.Minimatch;
 import minimatch.Options;


### PR DESCRIPTION
This PR adds the full test coverage for minimatch (based on https://github.com/isaacs/minimatch/tree/master/test), except for expansion tests, since the feature is not implemented.

Currently of 137 test cases:
- 7 are throwing an exception
- 31 are failing

Once we are green on all of them, it would be good to set up the project, so that AllMinimatchTests class is run after every build.
